### PR TITLE
Specify the priority between path_info and param

### DIFF
--- a/lib/CGI/Application.pm
+++ b/lib/CGI/Application.pm
@@ -1965,6 +1965,27 @@ will try to set the run mode from the first part of $ENV{PATH_INFO} (before the
 first "/"). To specify that you would rather get the run mode name from the 2nd
 part of $ENV{PATH_INFO}:
 
+ $webapp->mode_param(
+ 	path_info=> 1,
+ 	param =>'rm',
+ 	priority => 'path'
+ );
+ 
+With the option C<< 'priority' => 'param' >> you can determine, that, if a form 
+parameter is named that will contain the name of the run mode, this one should 
+also be used, if C<< path_info >> is set to a true value. This gives you more 
+flexibility. You can specify a run mode with a hidden field or with a button 
+and can display any path you want. Especially specifying a runmode with a button 
+as follows is now also possible, if mode_param{'path_info'} is set to a true 
+value:
+
+ <form action=\"/welcome/mode2\" method=\"post\">
+ <button name=\"rm\" value=\"mode3\">Go to mode3</button>
+ </form>
+
+With C<< 'priority' => 'param' >> the runmode mode3 is opened, although 
+'/welcome/mode2' is displayed in the adress bar
+
  $webapp->mode_param( path_info=> 2 );
 
 This also demonstrates that you don't need to pass in the C<param> hash key. It will
@@ -2040,10 +2061,11 @@ sub mode_param {
 			# If priority is set to param and a formular field with the 
 			# defined mode_param exist, do nothing (i.e. take ${param} see above, 
 			# not path_info!
-			if ( $p{priority} eq 'param' && $self->query->param("$mode_param")) {
-				
+			if ( $p{priority} eq 'param') {
+				$self->mode_param_priority( $p{priority} );
 			}
-			else {
+
+			unless ($p{priority} eq 'param' && $self->query->param("$mode_param") ) {
 				$mode_param = (length $pi) ?  { run_mode => $pi } : $mode_param;
 			}
 		}
@@ -2056,6 +2078,21 @@ sub mode_param {
 	}
 
 	return $self->{__MODE_PARAM};
+}
+
+sub mode_param_priority {
+	my $self = shift;
+	my ($mode_param_priority) = @_;
+
+	# First use?  Create new __MODE_PARAM
+	$self->{__MODE_PARAM_PRIORITY} = '' unless (exists($self->{__MODE_PARAM_PRIORITY}));
+
+	# If data is provided, set it
+	if (defined $mode_param_priority and length $mode_param_priority) {
+		$self->{__MODE_PARAM_PRIORITY} = $mode_param_priority;
+	}
+
+	return $self->{__MODE_PARAM_PRIORITY};
 }
 
 

--- a/lib/CGI/Application.pm
+++ b/lib/CGI/Application.pm
@@ -60,6 +60,11 @@ sub new {
 	if (exists($rprops->{QUERY})) {
 		$self->query($rprops->{QUERY});
 	}
+	
+	# Set the ENV variable for PSGI Application
+	if (exists($rprops->{ENV})) {
+		$self->env($rprops->{ENV});
+	}
 
 	# Set up init param() values
 	if (exists($rprops->{PARAMS})) {
@@ -246,6 +251,7 @@ sub psgi_app {
 	
 	# PR from alter https://github.com/markstos/CGI--Application/pull/17
         #if (not defined $args_to_new->{QUERY}) {
+            $args_to_new->{ENV} = $env;
             require CGI::PSGI;
             $args_to_new->{QUERY} = CGI::PSGI->new($env);
         #}
@@ -258,6 +264,8 @@ sub psgi_app {
 sub run_as_psgi {
     my $self = shift;
     $self->{__IS_PSGI} = 1;
+    my $env = shift;
+    $self->env($env);
 
     # Run doesn't officially support any args, but pass them through in case some sub-class uses them.
     return $self->run(@_);
@@ -535,7 +543,17 @@ sub delete {
 	delete $self->{__PARAMS}->{$param};
 }
 
-
+sub env {
+	my $self = shift;
+	my ($env) = @_;
+	
+	# If data is provided, set it!
+	if (defined($env)) {
+		$self->{__ENV} = $env;
+	}
+	
+	return $self->{__ENV};
+}
 sub query {
 	my $self = shift;
 	my ($query) = @_;
@@ -1018,6 +1036,11 @@ CGI::Application will instantiate its own CGI.pm query object.
 Under certain conditions, it might be useful to be able to use
 one which has already been created.
 
+B<ENV> - This optional parameter allows you to save the PSGI environment hash. 
+This is useful, because you can later get this environment hash in your Application
+Module with the method $self->env which could be important for using Plack::Middlewares 
+and similiar.
+
 B<PARAMS> - This parameter, if used, allows you to set a number
 of custom parameters at run-time.  By passing in different
 values in different instance scripts which use the same application
@@ -1077,14 +1100,16 @@ support to it.
 
 The simplest way to create and return a PSGI-compatible coderef. Pass in
 arguments to a hashref just as would to new. This returns a PSGI-compatible
-coderef, using L<CGI:::PSGI> as the query object. To use a different query
-object, construct your own object using C<< run_as_psgi() >>, as shown below.
+coderef, using L<CGI:::PSGI> as the query object and saving the PSGI 
+environment hash in the key ENV so that it can be accesed with C<< $self->env >>. 
+To use a different query object, construct your own object using C<< run_as_psgi() >>, 
+as shown below.
 
 It's possible that we'll change from CGI::PSGI to a different-but-compatible
 query object for PSGI support in the future, perhaps if CGI.pm adds native
 PSGI support.
 
-=head3 run_as_psgi()
+=head3 run_as_psgi($env)
 
  my $psgi_aref = $webapp->run_as_psgi;
 
@@ -1114,6 +1139,11 @@ Note that calling C<< run_as_psgi >> only handles the I<output> portion of the
 PSGI spec. to handle the input, you need to use a CGI.pm-like query object that
 is PSGI-compliant, such as L<CGI::PSGI>. This query object must provide L<psgi_header>
 and L<psgi_redirect> methods.
+
+You can pass the PSGI enivornment hash as first argument to the run_as_psgi. This 
+is the same as passing C<< {ENV => $env} >> to the method C<< new >> or C<< as_psgi >>.
+The benefit of this is that you can later in your Application Module easily access to this 
+PSGI environment hash by C<< $self->env >>
 
 The final result might look like this:
 
@@ -2020,10 +2050,10 @@ sub mode_param {
 		unless ((@_ % 2) == 0);
 		%p = @_;
 		$mode_param = $p{param};
-
+				
 		if ( $p{path_info} && $self->query->path_info() ) {
 			my $pi = $self->query->path_info();
-
+			
 			my $idx = $p{path_info};
 			# two cases: negative or positive index
 			# negative index counts from the end of path_info
@@ -2036,8 +2066,16 @@ sub mode_param {
 
 			# grab the requested field location
 			$pi = (split q'/', $pi)[$idx] || '';
-
-			$mode_param = (length $pi) ?  { run_mode => $pi } : $mode_param;
+			
+			# If priority is set to param and a formular field with the 
+			# defined mode_param exist, do nothing (i.e. take ${param} see above, 
+			# not path_info!
+			if ( $p{priority} eq 'param' && $self->query->param("$mode_param")) {
+				
+			}
+			else {
+				$mode_param = (length $pi) ?  { run_mode => $pi } : $mode_param;
+			}
 		}
 
 	}

--- a/lib/CGI/Application.pm
+++ b/lib/CGI/Application.pm
@@ -60,11 +60,6 @@ sub new {
 	if (exists($rprops->{QUERY})) {
 		$self->query($rprops->{QUERY});
 	}
-	
-	# Set the ENV variable for PSGI Application
-	if (exists($rprops->{ENV})) {
-		$self->env($rprops->{ENV});
-	}
 
 	# Set up init param() values
 	if (exists($rprops->{PARAMS})) {
@@ -251,7 +246,6 @@ sub psgi_app {
 	
 	# PR from alter https://github.com/markstos/CGI--Application/pull/17
         #if (not defined $args_to_new->{QUERY}) {
-            $args_to_new->{ENV} = $env;
             require CGI::PSGI;
             $args_to_new->{QUERY} = CGI::PSGI->new($env);
         #}
@@ -264,8 +258,6 @@ sub psgi_app {
 sub run_as_psgi {
     my $self = shift;
     $self->{__IS_PSGI} = 1;
-    my $env = shift;
-    $self->env($env);
 
     # Run doesn't officially support any args, but pass them through in case some sub-class uses them.
     return $self->run(@_);
@@ -543,17 +535,7 @@ sub delete {
 	delete $self->{__PARAMS}->{$param};
 }
 
-sub env {
-	my $self = shift;
-	my ($env) = @_;
-	
-	# If data is provided, set it!
-	if (defined($env)) {
-		$self->{__ENV} = $env;
-	}
-	
-	return $self->{__ENV};
-}
+
 sub query {
 	my $self = shift;
 	my ($query) = @_;
@@ -1036,11 +1018,6 @@ CGI::Application will instantiate its own CGI.pm query object.
 Under certain conditions, it might be useful to be able to use
 one which has already been created.
 
-B<ENV> - This optional parameter allows you to save the PSGI environment hash. 
-This is useful, because you can later get this environment hash in your Application
-Module with the method $self->env which could be important for using Plack::Middlewares 
-and similiar.
-
 B<PARAMS> - This parameter, if used, allows you to set a number
 of custom parameters at run-time.  By passing in different
 values in different instance scripts which use the same application
@@ -1100,16 +1077,14 @@ support to it.
 
 The simplest way to create and return a PSGI-compatible coderef. Pass in
 arguments to a hashref just as would to new. This returns a PSGI-compatible
-coderef, using L<CGI:::PSGI> as the query object and saving the PSGI 
-environment hash in the key ENV so that it can be accesed with C<< $self->env >>. 
-To use a different query object, construct your own object using C<< run_as_psgi() >>, 
-as shown below.
+coderef, using L<CGI:::PSGI> as the query object. To use a different query
+object, construct your own object using C<< run_as_psgi() >>, as shown below.
 
 It's possible that we'll change from CGI::PSGI to a different-but-compatible
 query object for PSGI support in the future, perhaps if CGI.pm adds native
 PSGI support.
 
-=head3 run_as_psgi($env)
+=head3 run_as_psgi()
 
  my $psgi_aref = $webapp->run_as_psgi;
 
@@ -1139,11 +1114,6 @@ Note that calling C<< run_as_psgi >> only handles the I<output> portion of the
 PSGI spec. to handle the input, you need to use a CGI.pm-like query object that
 is PSGI-compliant, such as L<CGI::PSGI>. This query object must provide L<psgi_header>
 and L<psgi_redirect> methods.
-
-You can pass the PSGI enivornment hash as first argument to the run_as_psgi. This 
-is the same as passing C<< {ENV => $env} >> to the method C<< new >> or C<< as_psgi >>.
-The benefit of this is that you can later in your Application Module easily access to this 
-PSGI environment hash by C<< $self->env >>
 
 The final result might look like this:
 
@@ -2050,10 +2020,10 @@ sub mode_param {
 		unless ((@_ % 2) == 0);
 		%p = @_;
 		$mode_param = $p{param};
-				
+
 		if ( $p{path_info} && $self->query->path_info() ) {
 			my $pi = $self->query->path_info();
-			
+
 			my $idx = $p{path_info};
 			# two cases: negative or positive index
 			# negative index counts from the end of path_info
@@ -2066,7 +2036,7 @@ sub mode_param {
 
 			# grab the requested field location
 			$pi = (split q'/', $pi)[$idx] || '';
-			
+
 			# If priority is set to param and a formular field with the 
 			# defined mode_param exist, do nothing (i.e. take ${param} see above, 
 			# not path_info!


### PR DESCRIPTION
Hello Martin,

with the following patch I would like to give the user the opportunity to specify with mode_param{'priority'=>'param'}  whether path_info or param should be the priority. At the moment if mode_param{'path_info' => 1} or similar is set, then always path_info is taken if it is not empty (this means is "/").

This patch gives the user more flexibility. You can specify a run mode with a hidden field or with a button and can display any path you want. Especially specifying a runmode with a button is at the moment not possible, when mode_param{'path_info'} is set to a true vale 

There are no backward compatibility problems expectable because without the additional option, CGI::App behaves as always.

POD doc will follow the next weeks (perhaps earlier)
Best wishes,
Max